### PR TITLE
use code-hike polar syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# gitclub-game
+# oso-golf
+
+Production: https://oso-golf.vercel.app/

--- a/build.js
+++ b/build.js
@@ -35,11 +35,6 @@ copySync(
   path.join(__dirname, 'public', 'vendor', 'vue-router'),
 );
 
-copySync(
-  path.join(__dirname, 'node_modules', 'prismjs'),
-  path.join(__dirname, 'public', 'vendor', 'prismjs'),
-);
-
 module.exports = async function build(watch) {
   if (watch) {
     const childProcess = exec('npm run tailwind:watch');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gitclub-game",
+  "name": "oso-golf",
   "version": "0.0.0",
   "scripts": {
     "lint": "eslint .",
@@ -11,6 +11,7 @@
     "test": "mocha ./test/*.test.js"
   },
   "dependencies": {
+    "@code-hike/lighter": "^0.9.4",
     "archetype": "0.13.0",
     "axios": "1.5.1",
     "dedent": "1.5.1",
@@ -20,7 +21,6 @@
     "mongoose": "7.5.3",
     "next": "^14.2.3",
     "oso-cloud": "1.1.1",
-    "prismjs": "1.29.0",
     "tailwindcss": "3.3.2",
     "vanillatoasts": "1.4.0",
     "vue": "3.x",

--- a/public/css/code.css
+++ b/public/css/code.css
@@ -1,0 +1,37 @@
+/* Code blocks */
+pre[class*="language-"] {
+	position: relative;
+	margin: .5em 0;
+	overflow: visible;
+	padding: 1px;
+}
+
+pre[class*="language-"] > code {
+	position: relative;
+	z-index: 1;
+	border-left: 6px solid #0550ae;
+	box-shadow: -1px 0px 0px 0px #ebfaff, 0px 0px 0px 1px #dfdfdf;
+	background-color: #fdfdfd;
+	background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
+	background-size: 3em 3em;
+	background-origin: content-box;
+	background-attachment: local;
+}
+
+code[class*="language-"] {
+	max-height: inherit;
+	height: inherit;
+	padding: 0 1em;
+	display: block;
+	overflow: auto;
+}
+
+/* Margin bottom to accommodate shadow */
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background-color: #fdfdfd;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	margin-bottom: 1em;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -64,15 +64,13 @@
       href="/vendor/vanillatoasts/vanillatoasts.css"
     />
     <link rel="stylesheet" type="text/css" href="/css/modal.css" />
+    <link rel="stylesheet" type="text/css" href="/css/code.css" />
     <link rel="stylesheet" type="text/css" href="/style.css" />
-    <link rel="stylesheet" href="/vendor/prismjs/themes/prism-coy.css" />
   </head>
   <body>
     <div id="content"></div>
     <script src="/vendor/vue/vue.global.js"></script>
     <script src="/vendor/vue-router/vue-router.global.js"></script>
-    <script src="/vendor/prismjs/prism.js" data-manual="true"></script>
-    <script src="/vendor/prismjs/components/prism-ruby.js"></script>
     <script src="/app.js"></script>
   </body>
 </html>

--- a/src/components.js
+++ b/src/components.js
@@ -1,10 +1,11 @@
 'use strict';
 
-// This file is auto-generated. Do not modify this file directly.
+  // This file is auto-generated. Do not modify this file directly.
 exports['add-role-fact'] = require('./add-role-fact/add-role-fact.js');
 exports['app-component'] = require('./app-component/app-component.js');
 exports['async-button'] = require('./async-button/async-button.js');
 exports['constraints'] = require('./constraints/constraints.js');
+exports['leaderboard'] = require('./leaderboard/leaderboard.js');
 exports['level'] = require('./level/level.js');
 exports['modal'] = require('./modal/modal.js');
 exports['oso-footer'] = require('./oso-footer/oso-footer.js');

--- a/src/level/level.html
+++ b/src/level/level.html
@@ -4,8 +4,8 @@
       Oso Policy
     </div>
     <pre
-      class="language-rb"
-    ><code class="language-rb" v-html="polarCode" ref="codeSnippet"></code></pre>
+      class="language-polar"
+    ><code class="language-polar" v-html="polarCode" ref="codeSnippet"></code></pre>
   </div>
   <div class="w-[60%]">
     <div class="text-2xl font-bold leading-9 tracking-tight mt-1" v-if="level">


### PR DESCRIPTION
Now that we're using https://github.com/code-hike/lighter/pull/40 for docs, we can also use it for oso-golf

New code highlighting looks like this:

![image](https://github.com/user-attachments/assets/73450381-b8e0-4930-813e-9b5421e4493d)

To support this, I needed to replace Prism with code-hike/lighter.
