### PR TITLE
Fix scoring for each round and overall score

### DIFF
--- a/backend/verifySolutionForLevel.js
+++ b/backend/verifySolutionForLevel.js
@@ -55,9 +55,7 @@ module.exports = async function handler(params) {
     }
 
     player.levelsCompleted = player.levelsCompleted + 1;
-    player.parPerLevel[level - 1] =
-      player.contextFacts.length - parByLevel[level - 1];
-    player.par = player.parPerLevel.reduce((sum, v) => sum + v);
+    player.scoreLevel(level, parByLevel);
     await player.save();
 
     return { player };

--- a/db/player.js
+++ b/db/player.js
@@ -2,34 +2,51 @@
 
 const mongoose = require('mongoose');
 
-const Player =
-  mongoose.models.Player ??
-  mongoose.model(
-    'Player',
-    mongoose.Schema({
-      sessionId: {
-        type: String,
-        required: true,
-      },
-      name: {
-        type: String,
-        requrired: true,
-      },
-      email: {
-        type: String,
-      },
-      parPerLevel: {
-        type: [Number],
-      },
-      par: {
-        type: Number,
-      },
-      levelsCompleted: {
-        type: Number,
-        default: 0,
-      },
-      contextFacts: [{ type: 'Mixed' }],
-    }),
-  );
+const playerSchema = mongoose.Schema({
+  sessionId: {
+    type: String,
+    required: true,
+  },
+  name: {
+    type: String,
+    requrired: true,
+  },
+  email: {
+    type: String,
+  },
+  parPerLevel: {
+    type: [Number],
+  },
+  par: {
+    type: Number,
+  },
+  levelsCompleted: {
+    type: Number,
+    default: 0,
+  },
+  contextFacts: [{ type: 'Mixed' }],
+});
+
+/*
+Calculate the delta from par for this level, and update overall delta from par,
+storing both on the Player instance
+*/
+playerSchema.methods.scoreLevel = function (level, parByLevel) {
+  // we don't currently keep track of strokes in each level,
+  // but we do keep track of delta from par, so we can figure out
+  // how many strokes were made in previous levels
+  const previousStrokes =
+    parByLevel.slice(0, level - 1).reduce((sum, v) => sum + v, 0) +
+    (this.par || 0);
+
+  // calculate strokes in this level by subtracting strokes in
+  // previous levels from total strokes, then calculate delta from par
+  this.parPerLevel[level - 1] =
+    this.contextFacts.length - previousStrokes - parByLevel[level - 1];
+
+  this.par = this.parPerLevel.reduce((sum, v) => sum + v, 0);
+};
+
+const Player = mongoose.models.Player ?? mongoose.model('Player', playerSchema);
 
 module.exports = Player;

--- a/test/player.test.js
+++ b/test/player.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const Player = require('../db/player');
+const assert = require('assert');
+const levels = require('../levels');
+const parByLevel = levels.map((level) => level.par);
+
+describe('scoring a level', function () {
+  it('scores each level and updates total score relative to par', function () {
+    const player = new Player();
+    player.contextFacts = [[]]; // 1 (empty, doesn't matter) fact, 1 below par for level 1
+    player.scoreLevel(1, parByLevel);
+    assert.equal(player.par, -1);
+
+    player.par = 0; // reset par
+    player.contextFacts = [[], [], []]; // 1 above par for level 1
+    player.scoreLevel(1, parByLevel);
+    assert.equal(player.par, 1);
+
+    player.contextFacts = [[], [], []]; // 1 below par for level 2, maintain previous overall score
+    player.scoreLevel(2, parByLevel);
+    assert.equal(player.par, -1);
+  });
+});


### PR DESCRIPTION
Scoring for each round is currently not independent, it includes strokes from previous rounds, UI suggests this is not intended (and is also contrary to conventional golf scoring).

(I promise I was at or under par for most of these 😄)

<img width="776" alt="Screenshot 2024-11-21 at 4 26 28 PM" src="https://github.com/user-attachments/assets/3c2d5989-3364-494a-ab7e-668ffe27e060">

<img width="620" alt="Screenshot 2024-11-21 at 4 27 04 PM" src="https://github.com/user-attachments/assets/3db68fff-4536-4e67-bf80-73eadc4023a7">
