### PR TITLE
clear context facts between levels

### DIFF
--- a/src/_methods/setLevel.js
+++ b/src/_methods/setLevel.js
@@ -28,7 +28,7 @@ module.exports = async function setLevel(
   state.facts = [];
 
   if (!retainContextFacts) {
-    await api.post('/api/clearContextFacts', {
+    await api.post('/api/clear-context-facts', {
       sessionId: state.sessionId,
     });
   }

--- a/src/_methods/setLevel.js
+++ b/src/_methods/setLevel.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const api = require('../api');
 const levels = require('../../levels');
 
 module.exports = async function setLevel(
@@ -25,4 +26,10 @@ module.exports = async function setLevel(
   state.results = [];
   state.showNextLevelButton = false;
   state.facts = [];
+
+  if (!retainContextFacts) {
+    await api.post('/api/clearContextFacts', {
+      sessionId: state.sessionId,
+    });
+  }
 };


### PR DESCRIPTION
Fix for the issue presented in https://github.com/osohq/oso-golf/pull/11 . The root cause of https://github.com/osohq/oso-golf/pull/11 is that we're not clearing the player's contextFacts in between levels, due to some mistakenly deleted code [here](https://github.com/osohq/oso-golf/commit/a8997153c6771b673403105286223f5dcaf4ab89#diff-21b0ea44af140a08fcd8819804d031b629d2f217bea08d739a9f85db4672ffa0).

Fixed version of #12 re: prettier issues and test failures